### PR TITLE
added uiautomator issue fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation group: 'com.android.support.test.uiautomator', name: 'uiautomator-v18', version: '2.1.3'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.shuttl.packagetest"
+    xmlns:tools="http://schemas.android.com/tools">
+
+
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
+
+    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="18"
+        tools:overrideLibrary="android_libs.ub_uiautomator"/>
+</manifest>

--- a/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
+++ b/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
@@ -102,7 +102,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
         // Dispatch Success Response and Validate Database
         // Wait for all other API to get served with the delayed response.
         UiUtils.safeSleep(8);
-        edgeCaseResponses.put("/sendGps", TestConstants.RESPONSE_TYPE.SUCCESS);
+        edgeCaseResponses.put("/" + TestConstants.GPS_PIPELINE_URL_END_POINT, TestConstants.RESPONSE_TYPE.SUCCESS);
         // Wait for the Sync service to be called.
         // Sync interval is taken as 7 seconds.
         UiUtils.safeSleep(5);

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -23,7 +23,7 @@ public class TestConstants {
     public static double startLatitude = 28.3992;
     public static double startLongitude = 77.0187;
 
-    public static String GPS_PIPELINE_URL_END_POINT = "sendGps";
+    public static String GPS_PIPELINE_URL_END_POINT = "sendGps/";
     public static String GPS_PIPELINE_URL = MockWebUtils.getMockWebServerUrl() + GPS_PIPELINE_URL_END_POINT;
     public static int NUMBER_OF_RETRIES_FOR_STOPPING_SERVICES = 3;
     public static int NUMBER_OF_RETRIES_FOR_STARTING_SERVICES = 3;

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.shuttl.packagetest">
+
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
+
+    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="18"
+        tools:overrideLibrary="android_libs.ub_uiautomator"/>
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
-
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.shuttl.packagetest">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
 
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="18"
-        tools:overrideLibrary="android_libs.ub_uiautomator"/>
 </manifest>


### PR DESCRIPTION
### ⚙️Description of problem solved or bug fixed:

**Problem 1**
Build failure for debug variant.

**Reason**
`uiautomator` library we are using supports `minSdkVersion >= 18` . 
But our other projects consuming GPS SDK supports `minSdkVersion >= 16` and therefore, Android devs recently updated `minSdkVersion`  from `18` to `16`. 
It broke build process of debug version with the specified error. 

```
Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 18 declared in library [androidx.test.uiautomator:uiautomator:2.2.0] /Users/mac/.gradle/caches/transforms-2/files-2.1/f657210b2c9774bb414ac0e47f468a93/uiautomator-2.2.0/AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 18,
		or use tools:overrideLibrary="android_libs.ub_uiautomator" to force usage (may lead to runtime failures)

```
**Solution**
Created new `AndroidManifest` file which overrides this default configuration specifically for our tests.  

_________________________________________________________________________________



**Problem 2**
After recent changes, Devs have added new check on ping service URL that it should end with `/`

**Solution**
Added `/` after our custom Ping service URL


 
![image](https://user-images.githubusercontent.com/38068550/85259490-cb70b500-b486-11ea-81e9-dac9408b13c6.png)
