### PR TITLE
Added sleep after starting location

### DIFF
--- a/app/src/androidTest/java/ServiceTests/StartStopService.java
+++ b/app/src/androidTest/java/ServiceTests/StartStopService.java
@@ -55,7 +55,7 @@ public class StartStopService extends BaseTestCase {
         LogUITest.debug("Starting 'Save Location Service' & 'Ping Location Service Via Init Module'");
         LocationsHelper.INSTANCE.initLocationsModule(activityTestRule.getActivity().getApplication(), null, locationConfigs, locationPingServiceCallback, intent);
 
-        UiUtils.safeSleep(3);
+        UiUtils.safeSleep(TestConstants.WAIT_FOR_SERVICE_TO_GET_STARTED);
 
         boolean isLocationSaveServiceRunning = ServiceHelper.isServiceRunning(LocationSaveService.class.getName());
 

--- a/app/src/androidTest/java/ServiceTests/StartStopService.java
+++ b/app/src/androidTest/java/ServiceTests/StartStopService.java
@@ -18,6 +18,7 @@ import testUtils.BaseTestCase;
 import testUtils.LogUITest;
 import testUtils.ServiceHelper;
 import testUtils.TestConstants;
+import testUtils.UiUtils;
 import testUtils.customAnnotations.AutoTest_Critical;
 import testUtils.customAnnotations.AutoTest_PingLocationService;
 import testUtils.customAnnotations.AutoTest_SaveLocationService;
@@ -54,6 +55,7 @@ public class StartStopService extends BaseTestCase {
         LogUITest.debug("Starting 'Save Location Service' & 'Ping Location Service Via Init Module'");
         LocationsHelper.INSTANCE.initLocationsModule(activityTestRule.getActivity().getApplication(), null, locationConfigs, locationPingServiceCallback, intent);
 
+        UiUtils.safeSleep(3);
 
         boolean isLocationSaveServiceRunning = ServiceHelper.isServiceRunning(LocationSaveService.class.getName());
 

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -13,7 +13,7 @@ public class TestConstants {
     Because Service is not started due to processing speed and low memory in RAM.
     This was causing Instrumentation Crash in tests.
      */
-    public static int WAIT_FOR_SERVICE_TO_GET_STARTED = 3;
+    public static int WAIT_FOR_SERVICE_TO_GET_STARTED = 2;
 
     // Inputs for random number generator
     public static int minValue = 1;

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -12,6 +12,8 @@ public class TestConstants {
     When we try to stop the service immediatelystarting it, It may fire the exception.
     Because Service is not started due to processing speed and low memory in RAM.
     This was causing Instrumentation Crash in tests.
+    Usually waiting for 500 ms helps ... But since we are running on simulators .
+    Therefore, adding more wait for safer side.
      */
     public static int WAIT_FOR_SERVICE_TO_GET_STARTED = 2;
 

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -8,8 +8,8 @@ public class TestConstants {
 
 
     /*
-    When we call startForgroundSerivce() method, Service do not started immediately.
-    When we try to stop the service immediatelystarting it, It may fire the exception.
+    When we call startForgroundSerivce() method, Service do not get started immediately.
+    When we try to stop the service immediately starting it, It may fire the exception.
     Because Service is not started due to processing speed and low memory in RAM.
     This was causing Instrumentation Crash in tests.
     Usually waiting for 500 ms helps ... But since we are running on simulators .

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -7,6 +7,14 @@ import testUtils.mockWebServer.MockWebUtils;
 public class TestConstants {
 
 
+    /*
+    When we call startForgroundSerivce() method, Service do not started immediately.
+    When we try to stop the service immediatelystarting it, It may fire the exception.
+    Because Service is not started due to processing speed and low memory in RAM.
+    This was causing Instrumentation Crash in tests.
+     */
+    public static int WAIT_FOR_SERVICE_TO_GET_STARTED = 3;
+
     // Inputs for random number generator
     public static int minValue = 1;
     public static int maxValue = 90;


### PR DESCRIPTION
### ⚙️Description of problem solved or bug fixed:
Instrumentation Crashed in `verifyStartStopLocationServicesViaInitModule` after this [commit](https://github.com/Shuttl-Tech/LocationsSync/commit/fb5dccfa1b4737153b76efcd3b2d8f742b478131) 
This issue will happen when we call startForgroundSerivce() method but at that time service was not started.
This happens when we stop the service and after immediately start service.
In this case service is not started due to processing speed and low memory in RAM but startForegroundService() method is called and fire the exception. 

#### Solution
Added some wait after we start the service. 



### 📸Flakiness Test Screenshot

![image](https://user-images.githubusercontent.com/38068550/92218550-e9ab5600-eeb6-11ea-9296-9936bf661887.png)

