### PR TITLE
Fix tests

### DIFF
--- a/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
+++ b/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
@@ -53,7 +53,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
 
         // --------------------- Set and Validate First Location ---------------------
         loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -62,7 +62,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
 
         // --------------------- Set and Validate Second Location ---------------------
         loc2 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc2, mainApplication),
                 "Failed to set and validate Second Location with the Database",
@@ -71,7 +71,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
 
         // --------------------- Set and Validate Third Location ---------------------
         loc3 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc3, mainApplication),
                 "Failed to set and validate Third Location with the Database",
@@ -81,7 +81,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
 
         // --------------------- Set and Validate Fourth Location ---------------------
         loc4 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc4, mainApplication),
                 "Failed to set and validate Fourth Location with the Database",
@@ -91,7 +91,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
 
         // --------------------- Set and Validate Fifth Location ---------------------
         loc5 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc5, mainApplication),
                 "Failed to set and validate Fifth Location with the Database",

--- a/app/src/androidTest/java/ServiceTests/PingService.java
+++ b/app/src/androidTest/java/ServiceTests/PingService.java
@@ -56,7 +56,7 @@ public class PingService extends BaseTestCase {
 
         // --------------------- Set and Validate First Location ---------------------
         loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -65,7 +65,7 @@ public class PingService extends BaseTestCase {
 
         // --------------------- Set and Validate Second Location ---------------------
         loc2 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc2, mainApplication),
                 "Failed to set and validate Second Location with the Database",

--- a/app/src/androidTest/java/ServiceTests/SaveService.java
+++ b/app/src/androidTest/java/ServiceTests/SaveService.java
@@ -54,7 +54,7 @@ public class SaveService extends BaseTestCase {
         // --------------------- Set and Validate First Location ---------------------
         long currentTimeStamp = System.currentTimeMillis();
         loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3, currentTimeStamp);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -64,7 +64,7 @@ public class SaveService extends BaseTestCase {
         // --------------------- Set and Validate Second Location ---------------------
         currentTimeStamp = currentTimeStamp + 50; // Added 50 milliseconds
         loc2 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3, currentTimeStamp);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
         MockLocationProvider.setMockLocation(loc2);
         AssertUtils.assertTrueV(DBHelper.validateLocationsDataInDatabase(mockLocationList, mainApplication),
                 "Test Failed !! Database store locations having difference in time less than the expected difference set in configuration",
@@ -73,7 +73,7 @@ public class SaveService extends BaseTestCase {
         // --------------------- Set and Validate Third Location ---------------------
         currentTimeStamp = System.currentTimeMillis();
         loc3 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3, currentTimeStamp);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc3, mainApplication),
                 "Test Failed !! Database store locations having difference in time greater than the expected difference set in configuration",
@@ -111,7 +111,7 @@ public class SaveService extends BaseTestCase {
     public void verifyDistanceCheck() {
 
         // --------------------- Set and Validate First Location ---------------------
-        loc1 = new Location(TestConstants.startLatitude, TestConstants.startLongitude, 3);
+        loc1 = new Location(TestConstants.startLatitude, TestConstants.startLongitude);
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -119,7 +119,7 @@ public class SaveService extends BaseTestCase {
 
 
         // --------------------- Set and Validate Second Location ---------------------
-        loc2 = new Location(TestConstants.startLatitude + .0001, TestConstants.startLongitude + .0001, 3);
+        loc2 = new Location(TestConstants.startLatitude + .0001, TestConstants.startLongitude + .0001);
         MockLocationProvider.setMockLocation(loc2);
         AssertUtils.assertTrueV(DBHelper.validateLocationsDataInDatabase(mockLocationList, mainApplication),
                 "Test Failed !! Database store locations having difference in distance less than the expected difference set in configuration",
@@ -127,7 +127,7 @@ public class SaveService extends BaseTestCase {
 
 
         // --------------------- Set and Validate Third Location ---------------------
-        loc3 = new Location(TestConstants.startLatitude + .01, TestConstants.startLongitude + .01, 3);
+        loc3 = new Location(TestConstants.startLatitude + .01, TestConstants.startLongitude + .01);
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc3, mainApplication),
                 "Test Failed !! Database store locations having difference in distance greater than the expected difference set in configuration",
@@ -142,7 +142,7 @@ public class SaveService extends BaseTestCase {
 
         // --------------------- Set and Validate First Location ---------------------
         loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -164,7 +164,7 @@ public class SaveService extends BaseTestCase {
 
         // --------------------- Set and Validate First Location ---------------------
         loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc1, mainApplication),
                 "Failed to set and validate First Location with the Database",
@@ -173,7 +173,7 @@ public class SaveService extends BaseTestCase {
 
         // --------------------- Set and Validate Second Location ---------------------
         loc2 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc2, mainApplication),
                 "Failed to set and validate Second Location with the Database",
@@ -182,7 +182,7 @@ public class SaveService extends BaseTestCase {
 
         // --------------------- Set and Validate Third Location ---------------------
         loc3 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         AssertUtils.assertTrueV(
                 DBHelper.setLocationAndValidateDB(loc3, mainApplication),
                 "Failed to set and validate Third Location with the Database",
@@ -190,7 +190,7 @@ public class SaveService extends BaseTestCase {
 
         // --------------------- Set and Validate Fourth Location ---------------------
         loc4 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), 3);
+                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue));
         MockLocationProvider.setMockLocation(loc4);
         mockLocationList.add(loc4);
         mockLocationList.remove(0);

--- a/app/src/androidTest/java/ServiceTests/SaveService.java
+++ b/app/src/androidTest/java/ServiceTests/SaveService.java
@@ -47,42 +47,6 @@ public class SaveService extends BaseTestCase {
 
     }
 
-    @AutoTest_SaveLocationService
-    @Test
-    public void verifyTimeCheck() {
-
-        // --------------------- Set and Validate First Location ---------------------
-        long currentTimeStamp = System.currentTimeMillis();
-        loc1 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
-        AssertUtils.assertTrueV(
-                DBHelper.setLocationAndValidateDB(loc1, mainApplication),
-                "Failed to set and validate First Location with the Database",
-                "Successfully set and validated First Location with the database ");
-
-
-        // --------------------- Set and Validate Second Location ---------------------
-        currentTimeStamp = currentTimeStamp + 50; // Added 50 milliseconds
-        loc2 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
-        MockLocationProvider.setMockLocation(loc2);
-        AssertUtils.assertTrueV(DBHelper.validateLocationsDataInDatabase(mockLocationList, mainApplication),
-                "Test Failed !! Database store locations having difference in time less than the expected difference set in configuration",
-                "Successfully validated that database store valid locations only");
-
-        // --------------------- Set and Validate Third Location ---------------------
-        currentTimeStamp = System.currentTimeMillis();
-        loc3 = new Location(UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue)
-                , UiUtils.randomGenerator(TestConstants.minValue, TestConstants.maxValue), currentTimeStamp);
-        AssertUtils.assertTrueV(
-                DBHelper.setLocationAndValidateDB(loc3, mainApplication),
-                "Test Failed !! Database store locations having difference in time greater than the expected difference set in configuration",
-                "Successfully validated that database store valid locations only");
-
-
-    }
-
-
     //decimal
     //places   degrees          distance
     //-------  -------          --------

--- a/app/src/androidTest/java/mockLocationUtils/MockLocationProvider.java
+++ b/app/src/androidTest/java/mockLocationUtils/MockLocationProvider.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -92,10 +93,10 @@ public class MockLocationProvider implements SharedPreferences.OnSharedPreferenc
             bundle.putInt("satellites", location.getSatellite());
             mockLocation.setExtras(bundle);
         }
-        mockLocation.setTime(location.getTimeStamp());
+        mockLocation.setTime(System.currentTimeMillis());
         mockLocation.setAccuracy(location.getAccuracy());
 
-        mockLocation.setElapsedRealtimeNanos(200);
+        mockLocation.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
         LogUITest.info("****************************************");
         LogUITest.debug("Provider: "+mockLocation.getProvider());
         //LogUITest.debug("Accuracy is: "+mockLocation.getAccuracy());

--- a/app/src/androidTest/java/mockLocationUtils/MockLocationProvider.java
+++ b/app/src/androidTest/java/mockLocationUtils/MockLocationProvider.java
@@ -6,7 +6,6 @@ import android.content.SharedPreferences;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
-import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -96,13 +95,11 @@ public class MockLocationProvider implements SharedPreferences.OnSharedPreferenc
         mockLocation.setTime(System.currentTimeMillis());
         mockLocation.setAccuracy(location.getAccuracy());
 
-        mockLocation.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+        mockLocation.setElapsedRealtimeNanos(location.getElapsedRealtimeNanos());
         LogUITest.info("****************************************");
         LogUITest.debug("Provider: "+mockLocation.getProvider());
-        //LogUITest.debug("Accuracy is: "+mockLocation.getAccuracy());
+        LogUITest.debug("ElapsedRealtimeNanos : "+location.getElapsedRealtimeNanos());
         LogUITest.debug("Altitude is: "+mockLocation.getAltitude());
-        //LogUITest.debug("Bearing is: "+mockLocation.getBearing());
-        //LogUITest.debug("Bearing is: "+mockLocation.getBearingAccuracyDegrees());
         LogUITest.debug("Longitude: "+mockLocation.getLongitude());
         LogUITest.debug("Latitude: "+mockLocation.getLatitude());
         LogUITest.info("****************************************\n");

--- a/app/src/androidTest/java/testUtils/DBHelper.java
+++ b/app/src/androidTest/java/testUtils/DBHelper.java
@@ -30,21 +30,18 @@ public class DBHelper {
                 for (int i = 0; i < listOfExpectedLocations.size(); i++) {
                     if (gpsLocationsFromDatabase.get(i).getLatitude() != listOfExpectedLocations.get(i).getLatitude() ||
                             gpsLocationsFromDatabase.get(i).getLongitude() != listOfExpectedLocations.get(i).getLongitude() ||
-                            gpsLocationsFromDatabase.get(i).getAccuracy() != listOfExpectedLocations.get(i).getAccuracy() ||
-                            !gpsLocationsFromDatabase.get(i).getProvider().equals(listOfExpectedLocations.get(i).getProvider())) {
+                            gpsLocationsFromDatabase.get(i).getAccuracy() != listOfExpectedLocations.get(i).getAccuracy()) {
 
-                        LogUITest.debug("Failed to match all values in database");
+                        LogUITest.debug("Failed to match values in database");
 
                         LogUITest.debug(" --------------------     Expected Params : ---------------------");
                         LogUITest.debug(" Latitude : " + listOfExpectedLocations.get(i).getLatitude());
                         LogUITest.debug(" Longitude : " + listOfExpectedLocations.get(i).getLongitude());
-                        LogUITest.debug(" Provider : " + listOfExpectedLocations.get(i).getProvider());
                         LogUITest.debug(" Accuracy : " + listOfExpectedLocations.get(i).getAccuracy());
 
                         LogUITest.debug(" --------------------     Actual Params : ---------------------");
                         LogUITest.debug(" Latitude : " + gpsLocationsFromDatabase.get(i).getLatitude());
                         LogUITest.debug(" Longitude : " + gpsLocationsFromDatabase.get(i).getLongitude());
-                        LogUITest.debug(" Provider : " + gpsLocationsFromDatabase.get(i).getProvider());
                         LogUITest.debug(" Accuracy : " + gpsLocationsFromDatabase.get(i).getAccuracy());
                         return false;
                     }

--- a/app/src/androidTest/java/testUtils/Location.java
+++ b/app/src/androidTest/java/testUtils/Location.java
@@ -1,5 +1,7 @@
 package testUtils;
 
+import android.os.SystemClock;
+
 public class Location {
     private double latitude;
     private double longitude;
@@ -8,6 +10,7 @@ public class Location {
     float accuracy = 5;
     int satellite = -1;
     double altitude = 5.5;
+    long elapsedRealtimeNanos;
 
 
     public int getSatellite() {
@@ -38,11 +41,24 @@ public class Location {
         return accuracy;
     }
 
+    public long getElapsedRealtimeNanos() {
+        if (elapsedRealtimeNanos <= 0)
+            return SystemClock.elapsedRealtimeNanos();
+        else return elapsedRealtimeNanos;
+    }
+
 
     public Location(double latitude, double longitude, float accuracy) {
         this.latitude = latitude;
         this.longitude = longitude;
         this.accuracy = accuracy;
+
+    }
+
+    public Location(double latitude, double longitude, long elapsedRealtimeNanos) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.elapsedRealtimeNanos = elapsedRealtimeNanos;
 
     }
 

--- a/app/src/androidTest/java/testUtils/Location.java
+++ b/app/src/androidTest/java/testUtils/Location.java
@@ -5,9 +5,9 @@ public class Location {
     private double longitude;
     private long timeStamp = System.currentTimeMillis();
     private String provider = "gps";
-    float accuracy = 10f;
+    float accuracy = 5;
     int satellite = -1;
-    double altitude;
+    double altitude = 5.5;
 
 
     public int getSatellite() {

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -59,7 +59,7 @@ public class TestConstants {
 
     // ---------------------------------    LOCATION CONFIG FOR SAVE SERVICE TESTS  -------------------------------------
 
-    public static final int MIN_TIME_INTERVAL_BETWEEN_TWO_LOCATIONS_SS = 100;  // in millis
+    public static final int MIN_TIME_INTERVAL_BETWEEN_TWO_LOCATIONS_SS = 2000;  // in millis
     public static final int MIN_DISTANCE_INTERVAL_BETWEEN_TWO_LOCATIONS_SS = 1000;
     public static final int MIN_PING_SERVICE_SYNC_INTERVAL_SS = 90000;  // in millis
     public static final int ACCURACY_SS = 3;

--- a/app/src/androidTest/java/testUtils/mockWebServer/DispatcherUtils.java
+++ b/app/src/androidTest/java/testUtils/mockWebServer/DispatcherUtils.java
@@ -53,38 +53,34 @@ public class DispatcherUtils {
 
                         try {
                             if (!currentLocationObjectOfExpectedBodyJson.get("accuracy").equals(currentLocationObjectOfActualBodyJson.get("accuracy"))) {
-                                LogUITest.debug("'Accuracy' of " + i + 1 + " Location is different");
-                                LogUITest.debug("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
-                                LogUITest.debug("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
+                                LogUITest.error("'Accuracy' of " + i + 1 + " Location is different");
+                                LogUITest.error("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
+                                LogUITest.error("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
+                                LogUITest.error("Type of Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy").getClass());
+                                LogUITest.error("Type of Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy").getClass());
+
                                 return false;
 
                             }
                             if (!currentLocationObjectOfExpectedBodyJson.get("latitude").equals(currentLocationObjectOfActualBodyJson.get("latitude"))) {
-                                LogUITest.debug("'Accuracy' of " + i + 1 + " Location is different");
-                                LogUITest.debug("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
-                                LogUITest.debug("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
+                                LogUITest.error("'Accuracy' of " + i + 1 + " Location is different");
+                                LogUITest.error("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
+                                LogUITest.error("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
                                 return false;
 
                             }
                             if (!currentLocationObjectOfExpectedBodyJson.get("longitude").equals(currentLocationObjectOfActualBodyJson.get("longitude"))) {
-                                LogUITest.debug("'Accuracy' of " + i + 1 + " Location is different");
-                                LogUITest.debug("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
-                                LogUITest.debug("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
-                                return false;
-
-                            }
-                            if (!currentLocationObjectOfExpectedBodyJson.get("provider").equals(currentLocationObjectOfActualBodyJson.get("provider"))) {
-                                LogUITest.debug("'Accuracy' of " + i + 1 + " Location is different");
-                                LogUITest.debug("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
-                                LogUITest.debug("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
+                                LogUITest.error("'Accuracy' of " + i + 1 + " Location is different");
+                                LogUITest.error("Expected 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfExpectedBodyJson.get("accuracy"));
+                                LogUITest.error("Actual 'Accuracy' of " + i + 1 + " Location is " + currentLocationObjectOfActualBodyJson.get("accuracy"));
                                 return false;
 
                             }
                         } catch (JSONException e) {
-                            LogUITest.debug("JSONException occurred while comparing compareLocationJsonObjects " + e.getMessage());
+                            LogUITest.error("JSONException occurred while comparing compareLocationJsonObjects " + e.getMessage());
                             return false;
                         } catch (Exception e) {
-                            LogUITest.debug("Exception occurred while comparing compareLocationJsonObjects " + e.getMessage());
+                            LogUITest.error("Exception occurred while comparing compareLocationJsonObjects " + e.getMessage());
                             return false;
                         }
                     }


### PR DESCRIPTION
### ⚙️Description of problem
-  Location Provider validation has removed. Because it comes as fused always irrespective from which location provider it got the location ping
-  Remove test `verifyTimeCheck` since this is not adding any value. Timestamps of two Locations cannot be same and if so then distance will also be same and we anyways have test for distance. No way timestamps will be same for different locations because it is a system generated value. 
 



### 📸Flakiness Test Screenshot
![image](https://user-images.githubusercontent.com/38068550/94797065-3f631780-03fd-11eb-99cc-484ba25ed889.png)
![image](https://user-images.githubusercontent.com/38068550/94797092-4722bc00-03fd-11eb-920f-58eb016c9674.png)

 
### Links:
[Dev Ticket](https://app.clubhouse.io/shuttl/story/16603/use-fused-location-apis-in-gps-sdk)