### PR TITLE
Added alarm param while initialising location sdk

### DIFF
--- a/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
+++ b/app/src/androidTest/java/ServiceTests/GpsSdkEndToEnd.java
@@ -40,6 +40,7 @@ public class GpsSdkEndToEnd extends BaseTestCase {
                         , TestConstants.XAPI_KEY_GLOBAL
                         , TestConstants.GPS_PIPELINE_URL
                         , TestConstants.WAKE_LOCK_ENABLED
+                        , TestConstants.ALARM_LOCK_ENABLED
                         , TestConstants.NOTIFICATION_ICON_ID);
 
         // Initiate Both Location Services

--- a/app/src/androidTest/java/ServiceTests/PingService.java
+++ b/app/src/androidTest/java/ServiceTests/PingService.java
@@ -42,6 +42,7 @@ public class PingService extends BaseTestCase {
                         , TestConstants.XAPI_KEY_GLOBAL
                         , TestConstants.GPS_PIPELINE_URL
                         , TestConstants.WAKE_LOCK_DISABLED
+                        , TestConstants.ALARM_LOCK_ENABLED
                         , TestConstants.NOTIFICATION_ICON_ID);
 
 

--- a/app/src/androidTest/java/ServiceTests/SaveService.java
+++ b/app/src/androidTest/java/ServiceTests/SaveService.java
@@ -40,6 +40,7 @@ public class SaveService extends BaseTestCase {
                         , TestConstants.XAPI_KEY_GLOBAL
                         , TestConstants.GPS_PIPELINE_URL
                         , TestConstants.WAKE_LOCK_ENABLED
+                        , TestConstants.ALARM_LOCK_ENABLED
                         , TestConstants.NOTIFICATION_ICON_ID);
 
 

--- a/app/src/androidTest/java/ServiceTests/StartStopService.java
+++ b/app/src/androidTest/java/ServiceTests/StartStopService.java
@@ -42,6 +42,7 @@ public class StartStopService extends BaseTestCase {
                         , TestConstants.XAPI_KEY_GLOBAL
                         , TestConstants.GPS_PIPELINE_URL
                         , TestConstants.WAKE_LOCK_ENABLED
+                        , TestConstants.ALARM_LOCK_ENABLED
                         , TestConstants.NOTIFICATION_ICON_ID);
 
 

--- a/app/src/androidTest/java/testUtils/TestConstants.java
+++ b/app/src/androidTest/java/testUtils/TestConstants.java
@@ -32,6 +32,8 @@ public class TestConstants {
 
     public static boolean WAKE_LOCK_ENABLED = true;
     public static boolean WAKE_LOCK_DISABLED = false;
+    public static boolean ALARM_LOCK_ENABLED = true;
+    public static boolean ALARM_LOCK_DISABLED = false;
 
     public static String GPS_PIPELINE_URL_END_POINT = "sendGps/";
     public static String GPS_PIPELINE_URL = MockWebUtils.getMockWebServerUrl() + GPS_PIPELINE_URL_END_POINT;

--- a/app/src/main/java/com/shuttl/packagetest/MainActivity.kt
+++ b/app/src/main/java/com/shuttl/packagetest/MainActivity.kt
@@ -53,7 +53,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         requestLocationPermission()
 
-        if (true) {
+        if (!BuildConfig.BUILD_TYPE.equals("debug")) {
             val intent = Intent(this, LocationPingService::class.java)
             intent.action = "STOP"
 


### PR DESCRIPTION
### ⚙️Description of problem solved or bug fixed:
-  Dev team has introduced new param for alarm flag while initialising gps sdk . Due to which test build is failing because we are unaware of such changes and we do not pass alarm flag while initialising the sdk 


### 📸Flakiness Test Screenshot

![image](https://user-images.githubusercontent.com/38068550/97439204-e16a1700-194b-11eb-8f72-a50ce06b8557.png)

![image](https://user-images.githubusercontent.com/38068550/97439223-e7f88e80-194b-11eb-9d55-c06f2a40ceab.png)
